### PR TITLE
Added Example of StyledStringElement to Touch

### DIFF
--- a/DialogExamples/DialogExamples.Touch/DialogExamples.Touch.csproj
+++ b/DialogExamples/DialogExamples.Touch/DialogExamples.Touch.csproj
@@ -10,7 +10,7 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>DialogExamples.Touch</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
-    <AssemblyName>DialogExamples.Touch</AssemblyName>
+    <AssemblyName>DialogExamplesTouch</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>

--- a/DialogExamples/DialogExamples.Touch/Views/FirstView.cs
+++ b/DialogExamples/DialogExamples.Touch/Views/FirstView.cs
@@ -10,20 +10,27 @@ using MonoTouch.Foundation;
 
 namespace DialogExamples.Touch.Views
 {
-    [Register("FirstView")]
-    public class FirstView : MvxDialogViewController
-    {
-        public override void ViewDidLoad()
-        {
-            base.ViewDidLoad();
+	[Register("FirstView")]
+	public class FirstView : MvxDialogViewController
+	{
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
 
-            var bindings = this.CreateInlineBindingTarget<FirstViewModel>();
+			var bindings = this.CreateInlineBindingTarget<FirstViewModel>();
 
-            // note that this list isn't bound - if the view model list changes, then the UI won't update it;s list
-            var radioChoices = from r in (ViewModel as FirstViewModel).DessertChoices
-                               select (Element)new RadioElement(r);
+			// note that this list isn't bound - if the view model list changes, then the UI won't update it;s list
+			var radioChoices = from r in (ViewModel as FirstViewModel).DessertChoices
+							   select (Element)new RadioElement(r);
 
-            Root = new RootElement("Example Root")
+			var radioGroup = new RootElement("Dessert", new RadioGroup("Dessert", 0)) {
+				new Section()
+				{
+					radioChoices
+				}
+			}.Bind(bindings, e => e.RadioSelected, vm => vm.CurrentDessertIndex);
+
+			Root = new RootElement("Example Root")
                 {
                     new Section("Your details")
                         {
@@ -35,21 +42,21 @@ namespace DialogExamples.Touch.Views
                             new BooleanElement("Remember me?", false).Bind(bindings, vm => vm.SwitchThis),
                             new CheckboxElement("Upgrade?").Bind(bindings, vm => vm.CheckThis),
                         },
-                    new Section("Radio")
-                        {
-                            new RootElement("Dessert", new RadioGroup("Dessert", 0))
-                                {
-                                    new Section()
-                                        {
-                                            radioChoices
-                                        }
-                                }.Bind(bindings, e => e.RadioSelected, vm => vm.CurrentDessertIndex)
-                        },
+					new Section("Radio")
+					{
+						(Element)radioGroup
+					},
                     new Section("Action")
                         {
                             new StringElement("Second").Bind(bindings, element => element.SelectedCommand, vm => vm.GoSecondCommand),
-                            new StringElement("Bindable Elements").Bind(bindings, element => element.SelectedCommand, vm => vm.BindableElementsCommand)  
-                        },
+							//styled button, for <= 3.0.10 you need to use this constructor to 
+							// > 3.0.10 can use new StyledStringElement("Bindable Elements")
+							new StyledStringElement("Bindable Elements", null, UITableViewCellStyle.Default) {
+								BackgroundColor = UIColor.Blue,
+								TextColor = UIColor.White,
+								Alignment = UITextAlignment.Center
+								}.Bind(bindings, element => element.SelectedCommand, vm => vm.BindableElementsCommand),
+		                    },
                     new Section("Debug out:")
                         {
                             new StringElement("Login is:").Bind(bindings, vm => vm.TextProperty),
@@ -59,6 +66,6 @@ namespace DialogExamples.Touch.Views
                             new StringElement("Selected Dessert Index is:").Bind(bindings, vm => vm.CurrentDessertIndex),
                         },
                 };
-        }
-    }
+		}
+	}
 }


### PR DESCRIPTION
based on https://github.com/slodge/MvvmCross/issues/402.

I did have an issue with an ambiguous call on bind where the Radio Group was added (between Add(Element) and Add(IEnumerable<Element>)). That is why is is moved out, casting the RootElement as an Element made the e.RadioSelected fail.
