### PR TITLE
RadioGroup in Dialog Example 

### DIFF
--- a/DialogExamples/DialogExamples.Droid/Views/FirstView.cs
+++ b/DialogExamples/DialogExamples.Droid/Views/FirstView.cs
@@ -44,7 +44,7 @@ namespace DialogExamples.Droid.Views
                                         {
                                             radioChoices
                                         }
-                                }.Bind(bindings, e => e.RadioSelected, vm => vm.CurrentDessertIndex)
+                                }.Bind(bindings, e => e.RadioSelected, vm => vm.CurrentDessertIndex) as Element
                         },
                     new Section("Action")
                         {


### PR DESCRIPTION
Hi Stuart, 

I am working on a dialog using the awesome MVX framework. I took a look at the Dialog Example in the tutorial and I found a little bug when I tried to run the app. As far as I can see, for the RadioGroup you need a new RootElement, but you cannot add this as a RootElement to the Section. You need to cast this as an Element right?

Regards
PerStaver
